### PR TITLE
defined(@array) is deprecated in Perl 

### DIFF
--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -369,10 +369,8 @@ if ($hz eq '--can') {
 		die "Usage: $0 HZ\n";
 	}
 
-	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
-		@val = compute_values($hz);
-	}
-	output($hz, @val);
+	$cv = $canned_values{$hz};
+ 	@val = defined($cv) ? @$cv : compute_values($hz);
+  	output($hz, @val);
 }
 exit 0;


### PR DESCRIPTION
defined(@array) is deprecated in Perl and doesn't work with the latest Perl version, fixed.
